### PR TITLE
fix(deps): eliminate `next-compose-plugins`

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,14 @@
 import withBundleAnalyzer from "@next/bundle-analyzer"
-import withPlugins from "next-compose-plugins"
 import { env } from "./env.mjs"
+
+const plugins = [
+  withBundleAnalyzer({ enabled: env.ANALYZE }),
+];
 
 /**
  * @type {import('next').NextConfig}
  */
-const config = withPlugins([[withBundleAnalyzer({ enabled: env.ANALYZE })]], {
+const config = {
   reactStrictMode: true,
   logging: {
     fetches: {
@@ -21,6 +24,6 @@ const config = withPlugins([[withBundleAnalyzer({ enabled: env.ANALYZE })]], {
       { source: "/ping", destination: "/api/health" },
     ]
   },
-})
+};
 
-export default config
+export default plugins.reduce((acc, next) => next(acc), config);

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "class-variance-authority": "^0.7.0",
     "lodash": "^4.17.21",
     "next": "^14.2.3",
-    "next-compose-plugins": "^2.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11302,11 +11302,6 @@ nerf-dart@^1.0.0:
   resolved "https://registry.yarnpkg.com/nerf-dart/-/nerf-dart-1.0.0.tgz#e6dab7febf5ad816ea81cf5c629c5a0ebde72c1a"
   integrity sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==
 
-next-compose-plugins@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz#020fc53f275a7e719d62521bef4300fbb6fde5ab"
-  integrity sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==
-
 next@^14.2.3:
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/next/-/next-14.2.3.tgz#f117dd5d5f20c307e7b8e4f9c1c97d961008925d"


### PR DESCRIPTION
Next.js v15 supports next.config.ts file, and there you will get an error about next-compose-plugins does not have `@types/next-compose-plugins`, so to not create file types with `declare module ...` for this specific problem it's easier to replace all the meaning of compose plugins with just a single `reduce` function.

detailed explanation here:
https://github.com/hashicorp/next-mdx-enhanced/issues/18#issuecomment-859196106